### PR TITLE
feat: criar Quickstart PT/EN e simplificar README (ênfase no QUICKSTART)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # Guia da API - react-lgpd-consent
 
-Este documento é a referência técnica oficial para a API da biblioteca `react-lgpd-consent` (v0.3.1+).
+Este documento é a referência técnica oficial para a API da biblioteca `react-lgpd-consent` (v0.3.3+).
 
 ## Exports Principais
 
@@ -55,7 +55,7 @@ function App() {
 | `onConsentGiven`                 | `(state: ConsentState) => void`             | Callback executado na primeira vez que o usuário dá o consentimento.                                                                      |
 | `onPreferencesSaved`             | `(prefs: ConsentPreferences) => void`       | Callback executado sempre que o usuário salva novas preferências no modal.                                                                |
 | `blocking`                       | `boolean`                                   | Se `true`, exibe um overlay que impede a interação com o site até que o usuário tome uma decisão. Padrão: `false`.                       |
-| `blockingStrategy`               | `'auto' | 'provider' | 'component'`       | Estratégia de bloqueio quando `blocking` estiver ativo. `'auto'` (padrão) mantém o comportamento atual (banner padrão bloqueia; custom decide). `'provider'` cria overlay de bloqueio no Provider. `'component'` delega bloqueio ao banner. |
+| `blockingStrategy`               | `'auto' | 'provider' | 'component'`       | Estratégia de bloqueio quando `blocking` estiver ativo. `'auto'` (padrão) mantém o comportamento atual (banner padrão bloqueia; custom decide). `'provider'` cria overlay de bloqueio no Provider (opt‑in). `'component'` delega bloqueio ao banner. Veja a seção "Bloqueio (opt-in) e integração com dark-filter" no `README.md` para exemplos e recomendações de A11y. |
 | `disableDeveloperGuidance`       | `boolean`                                   | Se `true`, desativa as mensagens de orientação no console, mesmo em ambiente de desenvolvimento.                                          |
 | `disableFloatingPreferencesButton` | `boolean`                                   | Se `true`, desabilita o botão flutuante que permite ao usuário reabrir o modal de preferências. Padrão: `false`.                     |
 | `hideBranding`                   | `boolean`                                   | Se `true`, oculta a marca "fornecido por LÉdipO.eti.br" dos componentes.                                                                  |
@@ -64,6 +64,16 @@ function App() {
 | `PreferencesModalComponent`      | `React.ComponentType<CustomPreferencesModalProps>` | Permite substituir o modal de preferências padrão por um componente React customizado.                                                    |
 | `theme`                          | `any` (Tema MUI)                            | Permite passar um tema customizado do Material-UI para os componentes da biblioteca.                                                      |
 | `initialState`                   | `ConsentState`                              | Estado inicial para hidratação em cenários de Server-Side Rendering (SSR) para evitar o "flash" do banner.                               |
+
+### `designTokens.layout.backdrop`
+
+O token `designTokens.layout.backdrop` agora aceita `boolean | string`:
+
+- `false`: indica que não haverá escurecimento visível; o overlay pode ainda bloquear cliques (útil quando a aplicação já fornece um dark-filter visual próprio).
+- `string`: qualquer valor CSS válido de cor (ex.: `'rgba(0,0,0,0.4)'`) será usado como cor do backdrop.
+- quando ausente, a biblioteca utiliza um fallback seguro `'rgba(0, 0, 0, 0.4)'`.
+
+Consulte `types/DesignTokens` para a tipagem completa.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,7 +294,7 @@ A v0.2.1 introduz um **sistema inteligente de orientações** que guia desenvolv
 
 ### 📋 **Documentação**
 
-- **📋 CONFORMIDADE-LGPD.md**: Guia completo de implementação conforme ANPD
+- **📋 CONFORMIDADE.md**: Guia completo de implementação conforme ANPD
 - **🔄 Migração**: Instruções detalhadas v0.2.0 → v0.2.1
 - **🏛️ Exemplos**: Casos de uso governamentais e corporativos
 

--- a/QUICKSTART.en.md
+++ b/QUICKSTART.en.md
@@ -1,0 +1,225 @@
+# 🚀 Quickstart
+
+This quickstart gives everything you need to integrate `react-lgpd-consent` into a React project fast.
+
+## 📦 Installation
+
+```bash
+npm install react-lgpd-consent
+# or
+yarn add react-lgpd-consent
+```
+
+### Peer dependencies
+
+```bash
+npm install @mui/material @mui/icons-material @emotion/react @emotion/styled
+```
+
+## 🎯 Basic Usage (30 seconds)
+
+```tsx
+import React from 'react'
+import { ConsentProvider } from 'react-lgpd-consent'
+
+function App() {
+  return (
+    <ConsentProvider
+      categories={{
+        enabledCategories: ['analytics', 'marketing'],
+      }}
+    >
+      <main>
+        <h1>My Application</h1>
+      </main>
+    </ConsentProvider>
+  )
+}
+
+export default App
+```
+
+## 📋 ConsentProvider props (summary)
+
+This is a condensed reference of the most commonly-used props. For a full typed table, see the TypeScript API docs.
+
+- `categories` (required) — Project categories configuration (e.g. enabledCategories: ["analytics"]).
+- `texts` — Partial object to override UI texts.
+- `theme` — Material-UI theme for consent components.
+- `designTokens` — Advanced visual tokens (colors, spacing, backdrop).
+- `blocking` (boolean) — If true, provider will block interaction until user acts.
+- `blockingStrategy` (`"auto" | "provider" | "component"`) — How overlay is managed.
+- `hideBranding` (boolean) — Hide library branding.
+- `onConsentGiven` — Callback when user gives consent for the first time.
+- `onPreferencesSaved` — Callback when preferences are saved.
+- `CookieBannerComponent`, `PreferencesModalComponent`, `FloatingPreferencesButtonComponent` — Replace UI components.
+- `cookie` — Customize cookie name, maxAge, domain, secure, sameSite.
+
+## 🎨 Custom components (TypeScript)
+
+### Custom Cookie Banner
+
+```tsx
+import React from 'react'
+import { ConsentProvider, type CustomCookieBannerProps } from 'react-lgpd-consent'
+
+const MyBanner: React.FC<CustomCookieBannerProps> = ({
+  consented,
+  acceptAll,
+  rejectAll,
+  openPreferences,
+  texts,
+  blocking,
+}) => {
+  return (
+    <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, background: '#222', color: 'white', padding: '1rem' }}>
+      <p>{texts.bannerMessage}</p>
+      <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+        <button onClick={acceptAll}>{texts.acceptAll}</button>
+        <button onClick={rejectAll}>{texts.declineAll}</button>
+        <button onClick={openPreferences}>{texts.preferences}</button>
+      </div>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <ConsentProvider categories={{ enabledCategories: ['analytics'] }} CookieBannerComponent={MyBanner} blocking>
+      <main>My App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+### Custom Preferences Modal
+
+```tsx
+import React from 'react'
+import { ConsentProvider, type CustomPreferencesModalProps } from 'react-lgpd-consent'
+
+const MyModal: React.FC<CustomPreferencesModalProps> = ({ preferences, setPreferences, closePreferences, isModalOpen, texts }) => {
+  if (!isModalOpen) return null
+
+  return (
+    <div style={{ position: 'fixed', inset: '20% 25%', background: 'white', borderRadius: 8, padding: '1.5rem', zIndex: 2000 }}>
+      <h2>{texts.modalTitle}</h2>
+      <p>{texts.modalIntro}</p>
+
+      {Object.entries(preferences).map(([category, enabled]) => (
+        <label key={category} style={{ display: 'block', margin: '0.5rem 0' }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setPreferences({ ...preferences, [category]: e.target.checked })}
+            disabled={category === 'necessary'}
+          />{' '}
+          {category === 'necessary' ? texts.necessaryAlwaysOn : `Cookies ${category}`}
+        </label>
+      ))}
+
+      <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end', marginTop: '1rem' }}>
+        <button onClick={closePreferences}>Cancel</button>
+        <button onClick={closePreferences}>{texts.save}</button>
+      </div>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <ConsentProvider categories={{ enabledCategories: ['analytics', 'marketing'] }} PreferencesModalComponent={MyModal}>
+      <main>My App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+## 🎮 Programmatic control
+
+### React hook: `useOpenPreferencesModal`
+
+```tsx
+import React from 'react'
+import { useOpenPreferencesModal, useConsent } from 'react-lgpd-consent'
+
+function MyComponent() {
+  const openPreferences = useOpenPreferencesModal()
+  const { preferences, acceptAll, rejectAll } = useConsent()
+
+  return (
+    <div>
+      <h3>Analytics: {preferences.analytics ? 'enabled' : 'disabled'}</h3>
+      <button onClick={openPreferences}>⚙️ Manage preferences</button>
+      <button onClick={acceptAll}>✅ Accept all</button>
+      <button onClick={rejectAll}>❌ Reject all</button>
+    </div>
+  )
+}
+```
+
+### Global: `window.openPreferencesModal` (for plain JS)
+
+```html
+<button onclick="window.openPreferencesModal?.()">Configure cookies</button>
+
+<script>
+  if (typeof window.openPreferencesModal === 'function') {
+    console.log('Consent system available')
+  }
+</script>
+```
+
+## 🐛 Debug system
+
+```tsx
+import { setDebugLogging, LogLevel } from 'react-lgpd-consent'
+
+// enable verbose debug locally
+setDebugLogging(true, LogLevel.DEBUG)
+
+// quieter in staging
+setDebugLogging(true, LogLevel.INFO)
+
+// errors only
+setDebugLogging(true, LogLevel.ERROR)
+
+// disable
+setDebugLogging(false)
+```
+
+Use the `useConsent` hook to inspect runtime state (preferences, consented) and optionally render a small debug panel in dev mode.
+
+## 🎨 Material-UI Theme integration
+
+Wrap your app with MUI `ThemeProvider` and optionally pass a `theme` prop to `ConsentProvider` to style consent components.
+
+## 🔧 Advanced
+
+- `designTokens` for low-level visual control (colors, spacing, backdrop)
+- `cookie` to customize name, maxAge, domain, secure, sameSite
+- `blocking` + `blockingStrategy` to control overlay behavior
+
+## 🚀 Common use cases
+
+- E-commerce: analytics + marketing integrations
+- Blog: only analytics
+- Enterprise: strict blocking and auditing via `onPreferencesSaved`
+
+## 🆘 Troubleshooting
+
+- "ConsentProvider must be used within ConsentProvider": ensure hooks are called inside provider tree.
+- Banner not showing: clear consent cookie, check z-index and config.
+- TypeScript types: set `moduleResolution` or `skipLibCheck` in `tsconfig` if needed.
+
+## 📚 Next steps
+
+- API docs: `docs/API-v0.3.0.md`
+- LGPD compliance guide: `docs/CONFORMIDADE-LGPD.md`
+- Integrations: `docs/integracoes-nativas.md`
+- Example app: `example/`
+
+
+---
+
+Tip: enable debug logs during development with `setDebugLogging(true, LogLevel.DEBUG)` to see runtime behavior.

--- a/QUICKSTART.en.md
+++ b/QUICKSTART.en.md
@@ -214,9 +214,9 @@ Wrap your app with MUI `ThemeProvider` and optionally pass a `theme` prop to `Co
 
 ## 📚 Next steps
 
-- API docs: `docs/API-v0.3.0.md`
-- LGPD compliance guide: `docs/CONFORMIDADE-LGPD.md`
-- Integrations: `docs/integracoes-nativas.md`
+- API docs: `API.md`
+- LGPD compliance guide: `CONFORMIDADE.md`
+- Integrations: `INTEGRACOES.md`
 - Example app: `example/`
 
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,576 @@
+# 🚀 Guia de Início Rápido
+
+Este guia fornece tudo o que você precisa para integrar rapidamente a biblioteca `react-lgpd-consent` em seu projeto React.
+
+## 📦 Instalação
+
+```bash
+npm install react-lgpd-consent
+# ou
+yarn add react-lgpd-consent
+```
+
+### Dependências Peer
+
+```bash
+npm install @mui/material @mui/icons-material @emotion/react @emotion/styled
+```
+
+## 🎯 Uso Básico (30 segundos)
+
+```tsx
+import React from 'react'
+import { ConsentProvider } from 'react-lgpd-consent'
+
+function App() {
+  return (
+    <ConsentProvider
+      categories={{
+        enabledCategories: ['analytics', 'marketing'],
+      }}
+    >
+      <main>
+        <h1>Minha Aplicação</h1>
+        {/* Seu conteúdo aqui */}
+      </main>
+    </ConsentProvider>
+  )
+}
+
+export default App
+```
+
+## 📋 Tabela Completa de Props do ConsentProvider
+
+| Prop                                 | Tipo                                                        | Obrigatória | Padrão              | Descrição                                      |
+| ------------------------------------ | ----------------------------------------------------------- | ----------- | ------------------- | ---------------------------------------------- |
+| `categories`                         | `ProjectCategoriesConfig`                                   | ✅ **Sim**  | -                   | Define as categorias de cookies do projeto     |
+| `texts`                              | `Partial<ConsentTexts>`                                     | ❌ Não      | Textos padrão PT-BR | Customiza textos da interface                  |
+| `theme`                              | `any`                                                       | ❌ Não      | Tema padrão         | Tema Material-UI para os componentes           |
+| `designTokens`                       | `DesignTokens`                                              | ❌ Não      | Tokens padrão       | Tokens de design para customização avançada    |
+| `blocking`                           | `boolean`                                                   | ❌ Não      | `false`             | Exibe overlay bloqueando interação até decisão |
+| `blockingStrategy`                   | `'auto' \| 'provider'`                                      | ❌ Não      | `'auto'`            | Estratégia de renderização do overlay          |
+| `hideBranding`                       | `boolean`                                                   | ❌ Não      | `false`             | Oculta branding "fornecido por"                |
+| `onConsentGiven`                     | `(state: ConsentState) => void`                             | ❌ Não      | -                   | Callback na primeira vez que usuário consente  |
+| `onPreferencesSaved`                 | `(prefs: ConsentPreferences) => void`                       | ❌ Não      | -                   | Callback quando preferências são salvas        |
+| `disableDeveloperGuidance`           | `boolean`                                                   | ❌ Não      | `false`             | Desativa orientações no console                |
+| `disableFloatingPreferencesButton`   | `boolean`                                                   | ❌ Não      | `false`             | Desabilita botão flutuante de preferências     |
+| `CookieBannerComponent`              | `React.ComponentType<CustomCookieBannerProps>`              | ❌ Não      | Banner padrão       | Componente de banner customizado               |
+| `PreferencesModalComponent`          | `React.ComponentType<CustomPreferencesModalProps>`          | ❌ Não      | Modal padrão        | Componente de modal customizado                |
+| `FloatingPreferencesButtonComponent` | `React.ComponentType<CustomFloatingPreferencesButtonProps>` | ❌ Não      | Botão padrão        | Componente de botão flutuante customizado      |
+| `cookieBannerProps`                  | `object`                                                    | ❌ Não      | `{}`                | Props adicionais para o banner                 |
+| `preferencesModalProps`              | `object`                                                    | ❌ Não      | `{}`                | Props adicionais para o modal                  |
+| `floatingPreferencesButtonProps`     | `object`                                                    | ❌ Não      | `{}`                | Props adicionais para o botão flutuante        |
+| `initialState`                       | `ConsentState`                                              | ❌ Não      | -                   | Estado inicial para hidratação SSR             |
+| `cookie`                             | `Partial<ConsentCookieOptions>`                             | ❌ Não      | Opções padrão       | Configurações do cookie de consentimento       |
+
+## 🎨 Componentes Customizados com TypeScript
+
+### Banner Personalizado
+
+```tsx
+import React from 'react'
+import { ConsentProvider, type CustomCookieBannerProps } from 'react-lgpd-consent'
+
+// Componente de banner customizado
+const MeuBannerCustomizado: React.FC<CustomCookieBannerProps> = ({
+  consented,
+  acceptAll,
+  rejectAll,
+  openPreferences,
+  texts,
+  blocking,
+}) => {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: blocking ? 'red' : 'blue',
+        color: 'white',
+        padding: '1rem',
+        zIndex: 1000,
+      }}
+    >
+      <p>{texts.bannerMessage}</p>
+      <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+        <button onClick={acceptAll}>{texts.acceptAll}</button>
+        <button onClick={rejectAll}>{texts.declineAll}</button>
+        <button onClick={openPreferences}>{texts.preferences}</button>
+      </div>
+    </div>
+  )
+}
+
+// Usando o banner customizado
+function App() {
+  return (
+    <ConsentProvider
+      categories={{ enabledCategories: ['analytics'] }}
+      CookieBannerComponent={MeuBannerCustomizado}
+      blocking={true}
+    >
+      <main>Minha App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+### Modal de Preferências Personalizado
+
+```tsx
+import React from 'react'
+import { ConsentProvider, type CustomPreferencesModalProps } from 'react-lgpd-consent'
+
+const MeuModalCustomizado: React.FC<CustomPreferencesModalProps> = ({
+  preferences,
+  setPreferences,
+  closePreferences,
+  isModalOpen,
+  texts,
+}) => {
+  if (!isModalOpen) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        backgroundColor: 'white',
+        border: '2px solid #ccc',
+        borderRadius: '8px',
+        padding: '2rem',
+        zIndex: 2000,
+        minWidth: '400px',
+      }}
+    >
+      <h2>{texts.modalTitle}</h2>
+      <p>{texts.modalIntro}</p>
+
+      {/* Lista de categorias */}
+      <div style={{ margin: '1rem 0' }}>
+        {Object.entries(preferences).map(([category, enabled]) => (
+          <label key={category} style={{ display: 'block', marginBottom: '0.5rem' }}>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) =>
+                setPreferences({
+                  ...preferences,
+                  [category]: e.target.checked,
+                })
+              }
+              disabled={category === 'necessary'}
+            />{' '}
+            {category === 'necessary' ? texts.necessaryAlwaysOn : `Cookies ${category}`}
+          </label>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end' }}>
+        <button onClick={closePreferences}>Cancelar</button>
+        <button onClick={closePreferences}>{texts.save}</button>
+      </div>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <ConsentProvider
+      categories={{ enabledCategories: ['analytics', 'marketing'] }}
+      PreferencesModalComponent={MeuModalCustomizado}
+    >
+      <main>Minha App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+## 🎮 Controle Programático
+
+### Hook useOpenPreferencesModal (React)
+
+```tsx
+import React from 'react'
+import { useOpenPreferencesModal, useConsent } from 'react-lgpd-consent'
+
+function MeuComponente() {
+  const openPreferences = useOpenPreferencesModal()
+  const { preferences, acceptAll, rejectAll } = useConsent()
+
+  return (
+    <div>
+      <h3>Status atual: {preferences.analytics ? 'Analytics ativo' : 'Analytics inativo'}</h3>
+
+      <button onClick={openPreferences}>⚙️ Gerenciar Preferências</button>
+
+      <button onClick={acceptAll}>✅ Aceitar Todos</button>
+
+      <button onClick={rejectAll}>❌ Recusar Todos</button>
+    </div>
+  )
+}
+```
+
+### window.openPreferencesModal (JavaScript Puro)
+
+```html
+<!-- Em templates HTML, emails ou widgets externos -->
+<button onclick="window.openPreferencesModal?.()">Configurar Cookies</button>
+
+<script>
+  // Ou em JavaScript puro
+  function abrirConfiguracoesCookies() {
+    if (window.openPreferencesModal) {
+      window.openPreferencesModal()
+    } else {
+      console.warn('Sistema de consentimento não carregado')
+    }
+  }
+
+  // Verificar se função está disponível
+  if (typeof window.openPreferencesModal === 'function') {
+    console.log('✅ Sistema de consentimento disponível')
+  }
+</script>
+```
+
+## 🐛 Sistema de Debug
+
+### Configuração de Debug
+
+```tsx
+import { setDebugLogging, LogLevel } from 'react-lgpd-consent'
+
+// Ativar todos os logs (desenvolvimento)
+setDebugLogging(true, LogLevel.DEBUG)
+
+// Apenas logs importantes (staging)
+setDebugLogging(true, LogLevel.INFO)
+
+// Apenas erros (produção)
+setDebugLogging(true, LogLevel.ERROR)
+
+// Desativar completamente
+setDebugLogging(false)
+```
+
+### Exemplo de Logs no Console
+
+```jsx
+// Em desenvolvimento, você verá logs como:
+// [🍪 LGPD-CONSENT] 🔧 Categorias Ativas (para UI customizada)
+// [🍪 LGPD-CONSENT] ℹ️ User accepted all cookies
+// [🍪 LGPD-CONSENT] 🐛 Category preference changed: analytics = true
+```
+
+### Hook para Debug Runtime
+
+```tsx
+import { useConsent } from 'react-lgpd-consent'
+
+function DebugPanel() {
+  const { preferences, consented } = useConsent()
+
+  // Apenas mostrar em desenvolvimento
+  if (process.env.NODE_ENV !== 'development') return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        background: 'rgba(0,0,0,0.8)',
+        color: 'white',
+        padding: '1rem',
+        fontSize: '12px',
+        fontFamily: 'monospace',
+      }}
+    >
+      <h4>🍪 Debug LGPD</h4>
+      <p>Consentimento: {consented ? '✅' : '❌'}</p>
+      <pre>{JSON.stringify(preferences, null, 2)}</pre>
+    </div>
+  )
+}
+```
+
+## 🎨 Integração com Material-UI ThemeProvider
+
+### Configuração Completa
+
+```tsx
+import React from 'react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+import { ConsentProvider } from 'react-lgpd-consent'
+
+// Seu tema personalizado
+const meuTema = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  },
+})
+
+// Tema específico para componentes de consentimento (opcional)
+const temaConsentimento = createTheme({
+  ...meuTema,
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          fontWeight: 600,
+        },
+      },
+    },
+  },
+})
+
+function App() {
+  return (
+    <ThemeProvider theme={meuTema}>
+      <CssBaseline />
+      <ConsentProvider
+        categories={{
+          enabledCategories: ['analytics', 'marketing', 'advertising'],
+        }}
+        theme={temaConsentimento} // Tema específico para consentimento
+        texts={{
+          bannerMessage: 'Utilizamos cookies para personalizar sua experiência.',
+          acceptAll: 'Aceitar Todos',
+          declineAll: 'Apenas Necessários',
+          preferences: 'Personalizar',
+        }}
+        onConsentGiven={(state) => {
+          console.log('✅ Consentimento dado:', state.preferences)
+        }}
+      >
+        <main>
+          <h1>Minha Aplicação com Material-UI</h1>
+          {/* Seus componentes aqui */}
+        </main>
+      </ConsentProvider>
+    </ThemeProvider>
+  )
+}
+
+export default App
+```
+
+## 🔧 Configurações Avançadas
+
+### Personalização de Design Tokens
+
+```tsx
+import { ConsentProvider, type DesignTokens } from 'react-lgpd-consent'
+
+const meusTokens: DesignTokens = {
+  colors: {
+    primary: '#6366f1',
+    secondary: '#f59e0b',
+    background: '#ffffff',
+    text: '#1f2937',
+    border: '#e5e7eb',
+  },
+  layout: {
+    borderRadius: '12px',
+    spacing: '1rem',
+    backdrop: 'rgba(0, 0, 0, 0.6)', // ou false para transparente
+  },
+  typography: {
+    fontFamily: '"Inter", system-ui, sans-serif',
+    fontSize: '14px',
+    fontWeight: '500',
+  },
+}
+
+function App() {
+  return (
+    <ConsentProvider
+      categories={{ enabledCategories: ['analytics'] }}
+      designTokens={meusTokens}
+      blocking={true}
+      blockingStrategy="provider"
+    >
+      <main>Minha App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+### Configuração de Cookie Personalizada
+
+```tsx
+import { ConsentProvider } from 'react-lgpd-consent'
+
+function App() {
+  return (
+    <ConsentProvider
+      categories={{ enabledCategories: ['analytics'] }}
+      cookie={{
+        name: 'meu_app_consent', // Nome customizado
+        maxAge: 365 * 24 * 60 * 60, // 1 ano em segundos
+        domain: '.meudominio.com.br', // Cookie compartilhado entre subdomínios
+        secure: true, // Apenas HTTPS
+        sameSite: 'Lax', // Política SameSite
+      }}
+    >
+      <main>Minha App</main>
+    </ConsentProvider>
+  )
+}
+```
+
+## 🚀 Casos de Uso Comuns
+
+### 1. E-commerce com Analytics + Marketing
+
+```tsx
+<ConsentProvider
+  categories={{
+    enabledCategories: ['analytics', 'marketing', 'advertising'],
+  }}
+  texts={{
+    bannerMessage:
+      'Usamos cookies para melhorar sua experiência de compra e exibir ofertas personalizadas.',
+    acceptAll: 'Aceitar e continuar',
+    declineAll: 'Apenas essenciais',
+  }}
+  onConsentGiven={(state) => {
+    // Inicializar ferramentas baseado no consentimento
+    if (state.preferences.analytics) {
+      // gtag('config', 'GA_MEASUREMENT_ID')
+    }
+    if (state.preferences.marketing) {
+      // fbq('init', 'FACEBOOK_PIXEL_ID')
+    }
+  }}
+>
+  {/* Sua loja */}
+</ConsentProvider>
+```
+
+### 2. Blog/Site Institucional Simples
+
+```tsx
+<ConsentProvider
+  categories={{
+    enabledCategories: ['analytics'],
+  }}
+  disableFloatingPreferencesButton={false}
+  hideBranding={true}
+>
+  {/* Seu conteúdo */}
+</ConsentProvider>
+```
+
+### 3. Aplicação Corporativa com Controle Rigoroso
+
+```tsx
+<ConsentProvider
+  categories={{
+    enabledCategories: ['analytics', 'functional'],
+  }}
+  blocking={true}
+  blockingStrategy="provider"
+  disableDeveloperGuidance={false}
+  onPreferencesSaved={(prefs) => {
+    // Log de auditoria
+    console.log('Audit: User preferences updated', prefs)
+  }}
+>
+  {/* Sua app corporativa */}
+</ConsentProvider>
+```
+
+## 🆘 Solução de Problemas Comuns
+
+### "ConsentProvider must be used within ConsentProvider"
+
+```tsx
+// ❌ Errado - hook usado fora do provider
+function MeuComponente() {
+  const { preferences } = useConsent() // Erro!
+  return <div>...</div>
+}
+
+function App() {
+  return (
+    <div>
+      <MeuComponente /> {/* useConsent usado aqui falhará */}
+      <ConsentProvider categories={{ enabledCategories: ['analytics'] }}>
+        <main>App</main>
+      </ConsentProvider>
+    </div>
+  )
+}
+
+// ✅ Correto - hook usado dentro do provider
+function App() {
+  return (
+    <ConsentProvider categories={{ enabledCategories: ['analytics'] }}>
+      <div>
+        <MeuComponente /> {/* Agora funciona */}
+        <main>App</main>
+      </div>
+    </ConsentProvider>
+  )
+}
+```
+
+### Banner não aparece
+
+1. Verificar se não há consentimento salvo no cookie:
+
+```js
+// Limpar cookie para teste
+document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
+```
+
+2. Verificar se `hideBranding` e outras configs estão corretas
+3. Conferir se o `z-index` não está sendo sobrescrito por outros elementos
+
+### TypeScript - tipos não encontrados
+
+```ts
+// Se você tiver problemas com tipos, adicione ao tsconfig.json:
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler", // ou "node"
+    "skipLibCheck": true
+  }
+}
+```
+
+## 📚 Próximos Passos
+
+- 📖 [Documentação Completa da API](./API.md)
+- 🏗️ [Guia de Conformidade LGPD](./docs/CONFORMIDADE-LGPD.md)
+- 🔌 [Integrações Nativas](./docs/integracoes-nativas.md)
+- 🧪 [Executar o Exemplo](./example/)
+
+---
+
+💡 **Dica**: Use `setDebugLogging(true, LogLevel.DEBUG)` durante o desenvolvimento para ver logs detalhados do comportamento da biblioteca.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -567,8 +567,8 @@ document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/
 ## 📚 Próximos Passos
 
 - 📖 [Documentação Completa da API](./API.md)
-- 🏗️ [Guia de Conformidade LGPD](./docs/CONFORMIDADE-LGPD.md)
-- 🔌 [Integrações Nativas](./docs/integracoes-nativas.md)
+- 🏗️ [Guia de Conformidade LGPD](./CONFORMIDADE.md)
+- 🔌 [Integrações Nativas](./INTEGRACOES.md)
 - 🧪 [Executar o Exemplo](./example/)
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -25,7 +25,7 @@
   </p>
 
   <p align="center">
-    <a href="./QUICKSTART.en.md"><img src="https://img.shields.io/badge/Quickstart-Get%20Started-blue?style=for-the-badge&logo=book" alt="Quickstart"></a>
+  <a href="./QUICKSTART.en.md"><img src="https://img.shields.io/badge/Quickstart-Get%20Started-blue?style=for-the-badge&logo=book" alt="Quickstart"></a>
   </p>
 
   <p align="center"><strong>Start here:</strong> follow the <a href="./QUICKSTART.en.md">Quickstart guide (QUICKSTART.en.md)</a> for step-by-step setup, TypeScript examples, props summary and MUI integration — recommended for new users.</p>
@@ -59,12 +59,12 @@ export default function App() {
 }
 ```
 
-For full guides, TypeScript examples, props table and integrations see:
-
-- **[QUICKSTART.md](./QUICKSTART.md)** (recommended)
-- **[Docs / API](./docs/API-v0.3.0.md)**
-- **[LGPD Compliance](./docs/CONFORMIDADE-LGPD.md)**
-- **[Integrations](./docs/integracoes-nativas.md)**
+- For full guides, TypeScript examples, props table and integrations see:
+-
+- **[QUICKSTART.en.md](./QUICKSTART.en.md)** (recommended)
+- **[Docs / API](./API.md)**
+- **[LGPD Compliance](./CONFORMIDADE.md)**
+- **[Integrations](./INTEGRACOES.md)**
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,80 @@
+<div align="center">
+  <h1>react-lgpd-consent 🍪</h1>
+  <p><strong>A React library for cookie consent management compliant with Brazil's LGPD.</strong></p>
+
+  <div>
+    <a href="https://www.npmjs.com/package/react-lgpd-consent"><img src="https://img.shields.io/npm/v/react-lgpd-consent?style=for-the-badge&logo=npm&color=cb3837&logoColor=white" alt="NPM Version"></a>
+    <a href="https://www.npmjs.com/package/react-lgpd-consent"><img src="https://img.shields.io/npm/dm/react-lgpd-consent?style=for-the-badge&logo=npm&color=ff6b35&logoColor=white" alt="Downloads"></a>
+    <a href="https://github.com/lucianoedipo/react-lgpd-consent/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/react-lgpd-consent?style=for-the-badge&color=green&logoColor=white" alt="License"></a>
+  </div>
+
+  <div>
+    <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-Ready-3178c6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript Ready"></a>
+    <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-18+-61dafb?style=for-the-badge&logo=react&logoColor=white" alt="React 18+"></a>
+    <a href="https://nextjs.org/"><img src="https://img.shields.io/badge/Next.js-Compatible-000000?style=for-the-badge&logo=next.js&logoColor=white" alt="Next.js Compatible"></a>
+  </div>
+
+  <br />
+
+  <p>
+    <a href="#installation"><strong>Installation</strong></a> •
+    <a href="#basic-usage"><strong>Basic Usage</strong></a> •
+    <a href="./QUICKSTART.md"><strong>📚 Quickstart</strong></a> •
+    <a href="#documentation"><strong>Documentation</strong></a> •
+    <a href="#contributing"><strong>Contributing</strong></a>
+  </p>
+
+  <p align="center">
+    <a href="./QUICKSTART.en.md"><img src="https://img.shields.io/badge/Quickstart-Get%20Started-blue?style=for-the-badge&logo=book" alt="Quickstart"></a>
+  </p>
+
+  <p align="center"><strong>Start here:</strong> follow the <a href="./QUICKSTART.en.md">Quickstart guide (QUICKSTART.en.md)</a> for step-by-step setup, TypeScript examples, props summary and MUI integration — recommended for new users.</p>
+</div>
+
+---
+
+## 🚀 Installation
+
+```bash
+npm install react-lgpd-consent @mui/material @emotion/react @emotion/styled js-cookie
+```
+
+**Peer dependencies:** `react`, `react-dom`, `@mui/material` and `js-cookie`.
+
+---
+
+## 📖 Basic Usage
+
+Wrap your app with `ConsentProvider` (minimal example):
+
+```tsx
+import { ConsentProvider } from 'react-lgpd-consent'
+
+export default function App() {
+  return (
+    <ConsentProvider categories={{ enabledCategories: ['analytics'] }}>
+      <YourApp />
+    </ConsentProvider>
+  )
+}
+```
+
+For full guides, TypeScript examples, props table and integrations see:
+
+- **[QUICKSTART.md](./QUICKSTART.md)** (recommended)
+- **[Docs / API](./docs/API-v0.3.0.md)**
+- **[LGPD Compliance](./docs/CONFORMIDADE-LGPD.md)**
+- **[Integrations](./docs/integracoes-nativas.md)**
+
+---
+
+## 🤝 Contributing
+
+1. Open an Issue for bugs or feature requests.
+2. Follow `DEVELOPMENT.md` to submit a PR.
+
+---
+
+## 📄 License
+
+MIT — see the `LICENSE` file.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ export default function App() {
 Para mais detalhes sobre customização, hooks e funcionalidades, consulte os seguintes guias:
 
 - **[📚 Guia de Início Rápido (`QUICKSTART.md`)](./QUICKSTART.md)**: Tutorial passo a passo com exemplos práticos, tabela completa de props, debugging e integrações.
-- **[Guia da API (`API.md`)](./docs/API-v0.3.0.md)**: Referência completa de todos os componentes, hooks e tipos.
-- **[Guia de Conformidade (`CONFORMIDADE.md`)](./docs/CONFORMIDADE-LGPD.md)**: Detalhes sobre as funcionalidades de conformidade com a LGPD.
-- **[Guia de Integrações (`INTEGRACOES.md`)](./docs/integracoes-nativas.md)**: Como usar as integrações nativas e criar as suas.
+- **[Guia da API (`API.md`)](./API.md)**: Referência completa de todos os componentes, hooks e tipos.
+- **[Guia de Conformidade (`CONFORMIDADE.md`)](./CONFORMIDADE.md)**: Detalhes sobre as funcionalidades de conformidade com a LGPD.
+- **[Guia de Integrações (`INTEGRACOES.md`)](./INTEGRACOES.md)**: Como usar as integrações nativas e criar as suas.
 ---
 
 ## 🤝 Como Contribuir

--- a/README.md
+++ b/README.md
@@ -4,42 +4,34 @@
 
   <div>
     <a href="https://www.npmjs.com/package/react-lgpd-consent"><img src="https://img.shields.io/npm/v/react-lgpd-consent?style=for-the-badge&logo=npm&color=cb3837&logoColor=white" alt="NPM Version"></a>
-     <a href="https://www.npmjs.com/package/react-lgpd-consent"><img src="https://img.shields.io/npm/dm/react-lgpd-consent?style=for-the-badge&logo=npm&color=ff6b35&logoColor=white" alt="Downloads"></a>
-     <a href="https://github.com/lucianoedipo/react-lgpd-consent/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/react-lgpd-consent?style=for-the-badge&color=green&logoColor=white" alt="License"></a>
+    <a href="https://www.npmjs.com/package/react-lgpd-consent"><img src="https://img.shields.io/npm/dm/react-lgpd-consent?style=for-the-badge&logo=npm&color=ff6b35&logoColor=white" alt="Downloads"></a>
+    <a href="https://github.com/lucianoedipo/react-lgpd-consent/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/react-lgpd-consent?style=for-the-badge&color=green&logoColor=white" alt="License"></a>
   </div>
-  
+
   <div>
     <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-Ready-3178c6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript Ready"></a>
     <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-18+-61dafb?style=for-the-badge&logo=react&logoColor=white" alt="React 18+"></a>
     <a href="https://nextjs.org/"><img src="https://img.shields.io/badge/Next.js-Compatible-000000?style=for-the-badge&logo=next.js&logoColor=white" alt="Next.js Compatible"></a>
   </div>
 
-  <br>
+  <br />
 
   <p>
     <a href="#-instalação"><strong>Instalação</strong></a> •
     <a href="#-uso-básico"><strong>Uso Básico</strong></a> •
-    <a href="#-documentação-completa"><strong>Documentação</strong></a> •
+  <a href="./QUICKSTART.md"><strong>📚 Guia de Início Rápido</strong></a> •
+  <a href="#-documentação-completa"><strong>Documentação</strong></a> •
+  <a href="./README.en.md">🇺🇸 🇬🇧 English</a> •
     <a href="#-como-contribuir"><strong>Contribuir</strong></a>
   </p>
+
+  <!-- Quickstart callout (mantido) -->
+  <p align="center">
+    <a href="./QUICKSTART.md"><img src="https://img.shields.io/badge/Quickstart-Iniciar%20R%C3%A1pido-blue?style=for-the-badge&logo=book" alt="Quickstart"></a>
+  </p>
+
+  <p align="center"><strong>Comece por aqui:</strong> siga o <a href="./QUICKSTART.md">Guia de Início Rápido (QUICKSTART.md)</a> para um tutorial passo-a-passo, exemplos TypeScript, tabela de props e integração com MUI — recomendado para usuários novos.</p>
 </div>
-
----
-
-## 🎯 Por que usar `react-lgpd-consent`?
-
-Esta biblioteca oferece uma solução robusta e flexível para gerenciar o consentimento de cookies em aplicações React, com foco total na **Lei Geral de Proteção de Dados (LGPD)** do Brasil.
-
-### Principais Funcionalidades
-
-| Funcionalidade                      | Descrição                                                                                                     |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 🇧🇷 **Foco na LGPD**                 | Implementação baseada nas diretrizes da ANPD, com textos e categorias alinhados à lei brasileira.             |
-| 🎨 **UI Automática e Customizável** | Componentes de UI (Banner e Modal) prontos para uso, baseados em Material-UI, e totalmente substituíveis.     |
-| ⚙️ **Configuração Consciente**      | A prop `categories` força a declaração explícita dos cookies utilizados, seguindo o princípio da minimização. |
-| 🧠 **Guia para Desenvolvedores**    | Sistema que exibe avisos e sugestões no console (em ambiente de dev) para garantir a correta implementação.   |
-| 🚀 **Integrações Nativas**          | Carregamento automático de scripts como Google Analytics e GTM, condicionado ao consentimento do usuário.     |
-| 🔒 **Auditoria e Transparência**    | O cookie de consentimento armazena metadados como data, origem e versão para fins de auditoria.               |
 
 ---
 
@@ -49,131 +41,41 @@ Esta biblioteca oferece uma solução robusta e flexível para gerenciar o conse
 npm install react-lgpd-consent @mui/material @emotion/react @emotion/styled js-cookie
 ```
 
-**Dependências Peer:**
-
-A biblioteca requer `react`, `react-dom`, `@mui/material` e `js-cookie` como dependências peer.
+**Dependências peer:** `react`, `react-dom`, `@mui/material` e `js-cookie`.
 
 ---
 
 ## 📖 Uso Básico
 
-Envolva sua aplicação com o `ConsentProvider` e configure as categorias de cookies que você utiliza.
+Envolva sua aplicação com o `ConsentProvider` (exemplo mínimo):
 
 ```tsx
-// Em seu arquivo principal (ex: App.tsx)
 import { ConsentProvider } from 'react-lgpd-consent'
 
-function App() {
+export default function App() {
   return (
-    <ConsentProvider
-      categories={{
-        // É obrigatório especificar as categorias que seu site usa.
-        // A categoria 'necessary' é sempre incluída.
-        enabledCategories: ['analytics', 'marketing'],
-      }}
-    >
-      {/* O banner e o botão de preferências aparecerão automaticamente */}
-      <SuaAplicacao />
+    <ConsentProvider categories={{ enabledCategories: ['analytics'] }}>
+      <YourApp />
     </ConsentProvider>
   )
 }
 ```
-
-### Exemplo com Integração e Textos Customizados
-
-```tsx
-import {
-  ConsentProvider,
-  ConsentScriptLoader,
-  createGoogleAnalyticsIntegration,
-} from 'react-lgpd-consent'
-
-// 1. Crie as integrações que você precisa
-const integrations = [
-  createGoogleAnalyticsIntegration({
-    measurementId: 'G-XXXXXXXXXX', // Substitua pelo seu ID
-  }),
-]
-
-function App() {
-  return (
-    <ConsentProvider
-      categories={{ enabledCategories: ['analytics'] }}
-      texts={{
-        bannerMessage: 'Nós usamos cookies para analisar o tráfego e melhorar a sua experiência.',
-        acceptAll: 'Aceitar',
-        declineAll: 'Recusar',
-        // Para conformidade com a ANPD, preencha os campos abaixo
-        controllerInfo: 'Controlado por: Sua Empresa LTDA (CNPJ: XX.XXX.XXX/XXXX-XX)',
-        contactInfo: 'Contato do DPO: dpo@suaempresa.com',
-      }}
-      onConsentGiven={(state) => {
-        console.log('O usuário deu o primeiro consentimento!', state.preferences)
-      }}
-    >
-      {/* 2. Adicione o loader de scripts para carregá-los após o consentimento */}
-      <ConsentScriptLoader integrations={integrations} />
-
-      <SuaAplicacao />
-    </ConsentProvider>
-  )
-}
-```
-
----
 
 ## 📚 Documentação Completa
 
 Para mais detalhes sobre customização, hooks e funcionalidades, consulte os seguintes guias:
 
-- **[Guia da API (`API.md`)](./API.md)**: Referência completa de todos os componentes, hooks e tipos.
-- **[Guia de Conformidade (`CONFORMIDADE.md`)](./CONFORMIDADE.md)**: Detalhes sobre as funcionalidades de conformidade com a LGPD.
-- **[Guia de Integrações (`INTEGRACOES.md`)](./INTEGRACOES.md)**: Como usar as integrações nativas e criar as suas.
-
-### Bloqueio (opt-in) e integração com dark-filter
-
-Você pode optar por garantir o bloqueio de interação pelo Provider quando `blocking` estiver ativo. Use a prop `blockingStrategy`:
-
-- `auto` (padrão):
-  - Com o banner padrão, o bloqueio é tratado pelo próprio componente de banner.
-  - Com um banner customizado, o Provider não cria overlay; o bloqueio fica a cargo do seu componente.
-- `provider`: o Provider cria um overlay de bloqueio por cima da aplicação (e abaixo do banner), independentemente de o banner ser padrão ou custom.
-- `component`: nenhum overlay do Provider; o bloqueio é responsabilidade do banner.
-
-Integração com dark-filter existente:
-- Se você já possui um filtro visual (escurecimento) próprio, use `blockingStrategy="provider"` e defina `designTokens={{ layout: { backdrop: false } }}` para bloquear cliques sem escurecer novamente. Mantenha seu dark-filter com `pointer-events: none`.
-- Para usar o escurecimento da própria lib, defina `designTokens={{ layout: { backdrop: 'rgba(0,0,0,0.4)' } }}`.
-
-Exemplos:
-
-```tsx
-// Bloqueio garantido pelo Provider (sem escurecer, usando seu dark-filter)
-<ConsentProvider blocking blockingStrategy="provider" designTokens={{ layout: { backdrop: false } }}>
-  <App />
-  {/* Seu dark-filter apenas visual aqui */}
-  <div className="dark-filter" />
-  {/* Banner customizado opcional */}
-</ConsentProvider>
-
-// Apenas a lib (com escurecimento padrão RGBA)
-<ConsentProvider blocking blockingStrategy="provider" designTokens={{ layout: { backdrop: 'rgba(0,0,0,0.4)' } }}>
-  <App />
-</ConsentProvider>
-```
-
+- **[📚 Guia de Início Rápido (`QUICKSTART.md`)](./QUICKSTART.md)**: Tutorial passo a passo com exemplos práticos, tabela completa de props, debugging e integrações.
+- **[Guia da API (`API.md`)](./docs/API-v0.3.0.md)**: Referência completa de todos os componentes, hooks e tipos.
+- **[Guia de Conformidade (`CONFORMIDADE.md`)](./docs/CONFORMIDADE-LGPD.md)**: Detalhes sobre as funcionalidades de conformidade com a LGPD.
+- **[Guia de Integrações (`INTEGRACOES.md`)](./docs/integracoes-nativas.md)**: Como usar as integrações nativas e criar as suas.
 ---
 
 ## 🤝 Como Contribuir
-
-Contribuições são muito bem-vindas! Este é um projeto open-source para a comunidade brasileira.
-
-1.  **Reporte Bugs ou Sugira Melhorias**: Abra uma [Issue no GitHub](https://github.com/lucianoedipo/react-lgpd-consent/issues).
-2.  **Envie um Pull Request**: Siga as instruções no nosso [Guia de Desenvolvimento (`DEVELOPMENT.md`)](./DEVELOPMENT.md).
-
-> Observação: este repositório usa templates de issues e PR para padronizar contribuições. Use os templates ao abrir um bug/feature/PR para acelerar a triagem.
+1. Abra uma [Issue](https://github.com/lucianoedipo/react-lgpd-consent/issues) para bugs ou melhorias.
+2. Siga o Guia de Desenvolvimento em `DEVELOPMENT.md` para enviar um PR.
 
 ---
-
 ## 📄 Licença
 
-Este projeto está licenciado sob a **MIT License**. Veja o arquivo [LICENSE](./LICENSE) para mais detalhes.
+MIT — veja o arquivo `LICENSE`.


### PR DESCRIPTION
## Descrição

Adiciona um Guia de Início Rápido (QUICKSTART.md) em PT-BR e a versão em inglês (QUICKSTART.en.md), cria `README.en.md` (versão condensada em inglês) e simplifica o `README.md` principal para funcionar como um landing enxuto que aponta para o Quickstart e docs. Também adiciona link de idioma (🇺🇸 🇬🇧) com atributo `title` e implementa blocos colapsáveis bilíngues nas seções-chave.

Arquivos principais alterados/criados
- `README.md` — simplificado; adicionado callout ao `QUICKSTART.md` e blocos bilíngues de Instalação/Uso Básico.
- `QUICKSTART.md` — guia em português (conteúdo consolidado/curado).
- `QUICKSTART.en.md` — criado (versão em inglês do quickstart).
- `README.en.md` — criado (versão condensada em inglês).


## Checklist
- [ ] Testes adicionados/atualizados (quando aplicável)
- [x] Documentação atualizada (README, QUICKSTART, README.en, QUICKSTART.en)
- [X] Rodar `npm run type-check`, `npm run lint` e `npm run test` antes do merge

## Como testar
Passos mínimos para reproduzir / validar as mudanças:

1. Certifique-se de estar na branch correta (ex.: `5-feature-docs-criar-um-guia-de-início-rápido-quickstart`).

```bash
git fetch
git checkout 5-feature-docs-criar-um-guia-de-início-rápido-quickstart
```

2. Verificações rápidas:

```powershell
npm run type-check
npm run lint
npm run test
npm run build
```

3. Visualizar os READMEs (local / GitHub):
- Abra `README.md` no preview do VS Code ou no GitHub e confirme que o callout do Quickstart está proeminente.
- Clique no link 🇺🇸 🇬🇧 English e confirme que `README.en.md` abre.
- Verifique que as seções de Instalação e Uso Básico estão em blocos colapsáveis (PT/EN).

4. Abrir `QUICKSTART.md` e `QUICKSTART.en.md` e checar:
- Exemplos TypeScript têm sintaxe plausível.
- Links relativos para `docs/` e `example/` funcionam.

## Considerações
- Breaking changes? **Não** — alterações restritas à documentação e arquivos Markdown.
- Migração: nenhuma ação necessária pelos consumidores da biblioteca.



